### PR TITLE
Add one digits after K (thousand) for Total XP and XP gained

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -20,7 +20,7 @@ export function encodeHTML(str: string) {
 
 export function kFormatter(num: number) {
 	return Math.abs(num) > 999 ?
-		trunc(num / 1000) + 'k' :
+		trunc(num / 1000, 1) + 'k' :
 		num
 }
 


### PR DESCRIPTION
The string representation should be at least one decimal place after K (thousand) for Total XP earned, and Recent XP gained to make it more accurate.